### PR TITLE
Modelica2025 cfp

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -9,10 +9,12 @@ The Modelica Conference is organized by the Modelica Association and a local org
 
 ## Upcoming Conferences
 
- * The [American Modelica Conference 2024](/events/american2024/) The conference will take place at the **University of Connecticut in Storrs** in the [Innovation Partnership Building](https://techpark.uconn.edu/) from **October 14–16, 2024**.
- * The [Asian Modelica Conference 2024](/events/asian2024/) will take place at the **ICC Hotel in Jeju - Island** in South Korea from **December 12-13, 2024**. It is organized by [iVH](http://www.ivh.co.kr/) in cooperation with the [Modelica Association](https://modelica.org/association/).
- <!-- [16th International Modelica Conference](/events/modelica2025/) -->
  * The [16th International Modelica & FMI Conference](/events/modelica2025/) will be held in **Lucerne, Switzerland**, **Sep 8-10, 2025**. The event is organized by the [Lucerne University of Applied Sciences and Arts (HSLU)](https://www.hslu.ch/en/) in cooperation with the [Modelica Association](https://modelica.org/association/). It is an in-person event held in English that is open for sponsorship positions.
+
+ ## Recent Conferences
+
+  * The [American Modelica Conference 2024](/events/american2024/) The conference will take place at the **University of Connecticut in Storrs** in the [Innovation Partnership Building](https://techpark.uconn.edu/) from **October 14–16, 2024**.
+ * The [Asian Modelica Conference 2024](/events/asian2024/) will take place at the **ICC Hotel in Jeju - Island** in South Korea from **December 12-13, 2024**. It is organized by [iVH](http://www.ivh.co.kr/) in cooperation with the [Modelica Association](https://modelica.org/association/).
 
 ## Major rules for a Modelica Conference
 

--- a/content/events/modelica2025/_index.md
+++ b/content/events/modelica2025/_index.md
@@ -166,7 +166,7 @@ The conference is organized by Prof. Ulf Christian Müller from [HSLU](https://w
   - **Conference Co-Chair:** Prof. Dr. Ulf Christian Müller, University of Applied Sciences and Arts Lucerne
   - **Conference Co-Chair:** Dr. Dirk Zimmer, German Aerospace Center
   - **Board Member:** Prof. Francesco Casella, Politecnico di Milano
-  - **Board Member:** Prof. Lars Mikelsons, Augsburg University
+  - **Board Member:** Prof. Lars Mikelsons, University of Augsburg
   - **Board Member:** Dipl.-Math. Christian Bertsch, Robert Bosch GmbH
   - **Board Member:** Dr. Hubertus Tummescheit
   - **Board Member:** Dr. Rui Gao, RIGO TECH Co. Ltd.

--- a/content/events/modelica2025/_index.md
+++ b/content/events/modelica2025/_index.md
@@ -133,10 +133,10 @@ The Modelica & FMI conference will bring together people using Modelica and/or o
 
 ## Call for papers, user presentations and tutorials
 
-The call for papers and further information will go out in January 2025. 
+<!-- The call for papers and further information will go out in January 2025.  -->
 
-<!-- Please see the [call for papers](call2025) for details about paper submissions, and the calls for [industrial user presentations](call2025), tutorials, and vendor presentations. Please look at the [author instructions](authors) before submitting. The submission deadlines are as follows:  
-
+ Please see the [call for papers](call2025) for details about paper submissions, and the calls for [industrial user presentations](call2025), tutorials, and vendor presentations. Please look at the [author instructions](authors) before submitting. <!--The submission deadlines are as follows:   -->
+<!-- 
 - June 15, 2024 Submission of full papers
 - June 1, 2024 Submission of extended abstracts for presentation-only contributions, [workshops and tutorials]
 (https://docs.google.com/forms/d/e/1FAIpQLScsRLAe-YwK7yAQoW6B5KQQ87M_SU4dgj6eKnvpjG3h53HMGw/viewform) 

--- a/content/events/modelica2025/call2025.md
+++ b/content/events/modelica2025/call2025.md
@@ -22,7 +22,7 @@ You are encouraged to submit a full paper of at least 4 pages, with a maximum of
  - Modelica for teaching and education
  - FMI in Modelica and non-Modelica applications and tools
  
- Please see the  [Authors' Guide](../authors) for further information. The submission of your paper will be handled through the EasyChair Conference Management System. A link will be provided in this section once the system is available, along with further instructions.
+ Please see the  [Authors' Guide](../authors) for further information. The submission of your paper will be handled through the EasyChair Conference Management System (not available yet).
  
  <!-- You can upload your paper using the [EasyChair Conference Management System](https://www.easychair.org/conferences/?conf=namugamc2024). Please note this link only works properly if you 1) Have an account on [Easychair](https://www.easychair.org) and 2) are logged into the account when you click the link.   -->
 
@@ -30,10 +30,12 @@ You are encouraged to submit a full paper of at least 4 pages, with a maximum of
 | --- | --- |
 |June 15, 2024 |Deadline for paper submissions|
 |July 1, 2024 |Deadline for Industrial User Presentation submissions|
-|July 1, 2024 | [Workshops and Tutorials](https://docs.google.com/forms/d/e/1FAIpQLScsRLAe-YwK7yAQoW6B5KQQ87M_SU4dgj6eKnvpjG3h53HMGw/viewform), and Vendor Presentations|
+|July 1, 2024 | Workshops and Tutorials, and Vendor Presentations|
 |August 10, 2024|Notification of acceptance for papers and presentations|
 |August 30, 2024|Submission of final papers, presentations, and one-page abstracts|
 |October 14-16, 2024| American Modelica Conference 2024|
+<!-- |July 1, 2024 | [Workshops and Tutorials](https://docs.google.com/forms/d/e/1FAIpQLScsRLAe-YwK7yAQoW6B5KQQ87M_SU4dgj6eKnvpjG3h53HMGw/viewform), and Vendor Presentations| -->
+
  
 
 The conference proceedings will be published by the Modelica Association on its website and by  [Linköping University Electronic Press](http://www.ep.liu.se/).
@@ -45,7 +47,7 @@ You are encouraged to submit an  **extended abstract**  of 1-2 pages, related to
 
 -   LANG - Modelica Language
 -   LIB - Modelica Libraries
--   FMI - Functional Mockup Interface <!-- (doubles as the [FMI user meeting](fmi-user-meeting.html)) -->
+-   FMI - Functional Mockup Interface 
 -   eFMI - Functional Mockup Interface for embedded systems
 -   SSP - System Structure and Parameterization of Components for Virtual System Design
 -   DCP - Distributed Co-Simulation Protocol
@@ -63,7 +65,8 @@ Please note that purely tool-related presentations are not permitted for these a
 ## Call for Tutorials
 
 
-At the Modelica conference, several tutorials will take place in parallel. Each tutorial will last for up to 4 hours and includes a "hands-on-experience" session (participants are expected to have own notebook; the presenter will provide the presented tools). If you are interested, please use the application form for  [Workshops and Tutorials](https://docs.google.com/forms/d/e/1FAIpQLScsRLAe-YwK7yAQoW6B5KQQ87M_SU4dgj6eKnvpjG3h53HMGw/viewform).  The deadline for application is  **June 1st, 2024**; however, as only a limited number of tutorials can be held in parallel, we advise you to apply as early as possible.
+At the Modelica conference, several tutorials will take place in parallel. Each tutorial will last for up to 4 hours and includes a "hands-on-experience" session (participants are expected to have own notebook; the presenter will provide the presented tools). <!-- If you are interested, please use the application form for  [Workshops and Tutorials](https://docs.google.com/forms/d/e/1FAIpQLScsRLAe-YwK7yAQoW6B5KQQ87M_SU4dgj6eKnvpjG3h53HMGw/viewform) --> An application form for Workshops and Tutorials will be made available here in due course.
+The deadline for application is  **June 1st, 2024**; however, as only a limited number of tutorials can be held in parallel, we advise you to apply as early as possible.
 
 <!-- Tutorials are free for the participants, but especially for commercial tools the presenter is charged $250 per session, provided it is a hands on training tutorial, not just commercial presentation or demonstration (for product presentations see Vendor sessions above). Upon written request some tutorials, especially non-commercial, (e.g. FMI, Open Source libraries etc.), could be exempted from the fee by decision of the organising committee. -->
 

--- a/content/events/modelica2025/call2025.md
+++ b/content/events/modelica2025/call2025.md
@@ -39,7 +39,7 @@ Each paper will be individually referenced by a DOI.
 
 ## Call for Industrial User Presentations
 
-You are encouraged to submit an  **extended abstract**  of 1-2 pages, related to one of the existing or possibly new  [Modelica Association Projects](https://modelica.org/projects):
+You are encouraged to submit an  **extended abstract**  of 1-2 pages, related to one of the existing or possibly new  [Modelica Association Projects](https://modelica.org/community/projects/):
 
 -   LANG - Modelica Language
 -   LIB - Modelica Libraries

--- a/content/events/modelica2025/call2025.md
+++ b/content/events/modelica2025/call2025.md
@@ -69,7 +69,7 @@ At the Modelica conference, several tutorials will take place in parallel. Each 
 
 Decision about the acceptance of tutorials will be based upon Modelica/FMI relation of content and on the time of application.
 
-Payment of fees will be handled through our registration links via Eventbrite.
+Payment of fees will be handled through our registration links via EasyChair (not available yet).
 
 
 <!-- The authors of the 10% top papers submitted to the conference will be invited to submit an extended version after the conference, for inclusion in a special issue of an open-access, ISI-referenced journal. Please note that the extended papers will undergo a full peer-review process which is independent from the one of the Modelica Conference. -->

--- a/content/events/modelica2025/call2025.md
+++ b/content/events/modelica2025/call2025.md
@@ -28,12 +28,15 @@ You are encouraged to submit a full paper of at least 4 pages, with a maximum of
 
 | Date | |
 | --- | --- |
-|June 15, 2024 |Deadline for paper submissions|
-|July 1, 2024 |Deadline for Industrial User Presentation submissions|
-|July 1, 2024 | Workshops and Tutorials, and Vendor Presentations|
-|August 10, 2024|Notification of acceptance for papers and presentations|
-|August 30, 2024|Submission of final papers, presentations, and one-page abstracts|
-|October 14-16, 2024| American Modelica Conference 2024|
+|January 6, 2025 |Call for papers |
+|April 17, 2025 |Deadline for submissions|
+|June 1, 2025 | Deadline for Workshops and Tutorials, and Vendor Presentations|
+|June 1, 2025 | Deadline for Industrial User Presentation submissions|
+|June 16, 2025|Notification of acceptance for papers and presentations|
+|June 30, 2025|Deadline for early registration|
+|August 1, 2025|Submission of final papers, presentations, and one-page abstracts|
+|September 8-10, 2025| 16th International Modelica & FMI Conference|
+
 <!-- |July 1, 2024 | [Workshops and Tutorials](https://docs.google.com/forms/d/e/1FAIpQLScsRLAe-YwK7yAQoW6B5KQQ87M_SU4dgj6eKnvpjG3h53HMGw/viewform), and Vendor Presentations| -->
 
  
@@ -55,7 +58,7 @@ You are encouraged to submit an  **extended abstract**  of 1-2 pages, related to
 
 <!-- The extended abstract in PDF or MS Word format of about 500 words should be submitted through the  [EasyChair Conference Management System](https://www.easychair.org/conferences/?conf=namugamc2024) before **June 1st, 2024**. Please note this link only works properly if you 1) Have an account on [Easychair](https://www.easychair.org) and 2) are logged into the account when you click the link.  -->
 
-An extended abstract of approximately 500 words, in PDF or MS Word format, will need to be submitted through the EasyChair Conference Management System by June 1st, 2024. A submission link will be provided in this section once available, along with detailed instructions. Industrial user presentations are an excellent way to present recent results to the Modelica community with less effort and overhead than a full paper submission. Please indicate whether you plan to give your presentation on-site or remotely in the submission form. These industrial user presentations differ from paper presentations, which we expect to be in-person. 
+An extended abstract of approximately 500 words, in PDF or MS Word format, will need to be submitted through the EasyChair Conference Management System by **June 1st, 2025**. A submission link will be provided in this section once available, along with detailed instructions. Industrial user presentations are an excellent way to present recent results to the Modelica community with less effort and overhead than a full paper submission. Please indicate whether you plan to give your presentation on-site or remotely in the submission form. These industrial user presentations differ from paper presentations, which we expect to be in-person. 
 
 These abstracts will be peer-reviewed by experts, but no corresponding papers will be published in the conference proceedings.
 
@@ -66,7 +69,7 @@ Please note that purely tool-related presentations are not permitted for these a
 
 
 At the Modelica conference, several tutorials will take place in parallel. Each tutorial will last for up to 4 hours and includes a "hands-on-experience" session (participants are expected to have own notebook; the presenter will provide the presented tools). <!-- If you are interested, please use the application form for  [Workshops and Tutorials](https://docs.google.com/forms/d/e/1FAIpQLScsRLAe-YwK7yAQoW6B5KQQ87M_SU4dgj6eKnvpjG3h53HMGw/viewform) --> An application form for Workshops and Tutorials will be made available here in due course.
-The deadline for application is  **June 1st, 2024**; however, as only a limited number of tutorials can be held in parallel, we advise you to apply as early as possible.
+The deadline for application is  **June 1st, 2025**; however, as only a limited number of tutorials can be held in parallel, we advise you to apply as early as possible.
 
 <!-- Tutorials are free for the participants, but especially for commercial tools the presenter is charged $250 per session, provided it is a hands on training tutorial, not just commercial presentation or demonstration (for product presentations see Vendor sessions above). Upon written request some tutorials, especially non-commercial, (e.g. FMI, Open Source libraries etc.), could be exempted from the fee by decision of the organising committee. -->
 

--- a/content/events/modelica2025/call2025.md
+++ b/content/events/modelica2025/call2025.md
@@ -22,7 +22,9 @@ You are encouraged to submit a full paper of at least 4 pages, with a maximum of
  - Modelica for teaching and education
  - FMI in Modelica and non-Modelica applications and tools
  
- Please see the  [Authors' Guide](../authors) for further information. You can upload your paper using the [EasyChair Conference Management System](https://www.easychair.org/conferences/?conf=namugamc2024). Please note this link only works properly if you 1) Have an account on [Easychair](https://www.easychair.org) and 2) are logged into the account when you click the link.  
+ Please see the  [Authors' Guide](../authors) for further information. The submission of your paper will be handled through the EasyChair Conference Management System. A link will be provided in this section once the system is available, along with further instructions.
+ 
+ <!-- You can upload your paper using the [EasyChair Conference Management System](https://www.easychair.org/conferences/?conf=namugamc2024). Please note this link only works properly if you 1) Have an account on [Easychair](https://www.easychair.org) and 2) are logged into the account when you click the link.   -->
 
 | Date | |
 | --- | --- |
@@ -49,7 +51,9 @@ You are encouraged to submit an  **extended abstract**  of 1-2 pages, related to
 -   DCP - Distributed Co-Simulation Protocol
 
 
-The extended abstract in PDF or MS Word format of about 500 words should be submitted through the  [EasyChair Conference Management System](https://www.easychair.org/conferences/?conf=namugamc2024) before **June 1st, 2024**. Please note this link only works properly if you 1) Have an account on [Easychair](https://www.easychair.org) and 2) are logged into the account when you click the link. Industrial user presentations are an excellent way to present recent results to the Modelica community with less effort and overhead than a full paper submission. Please indicate whether you plan to give your presentation on-site or remotely in the submission form. These industrial user presentations differ from paper presentations, which we expect to be in-person. 
+<!-- The extended abstract in PDF or MS Word format of about 500 words should be submitted through the  [EasyChair Conference Management System](https://www.easychair.org/conferences/?conf=namugamc2024) before **June 1st, 2024**. Please note this link only works properly if you 1) Have an account on [Easychair](https://www.easychair.org) and 2) are logged into the account when you click the link.  -->
+
+An extended abstract of approximately 500 words, in PDF or MS Word format, will need to be submitted through the EasyChair Conference Management System by June 1st, 2024. A submission link will be provided in this section once available, along with detailed instructions. Industrial user presentations are an excellent way to present recent results to the Modelica community with less effort and overhead than a full paper submission. Please indicate whether you plan to give your presentation on-site or remotely in the submission form. These industrial user presentations differ from paper presentations, which we expect to be in-person. 
 
 These abstracts will be peer-reviewed by experts, but no corresponding papers will be published in the conference proceedings.
 
@@ -71,9 +75,9 @@ Payment of fees will be handled through our registration links via Eventbrite.
 <!-- The authors of the 10% top papers submitted to the conference will be invited to submit an extended version after the conference, for inclusion in a special issue of an open-access, ISI-referenced journal. Please note that the extended papers will undergo a full peer-review process which is independent from the one of the Modelica Conference. -->
 
 
-## Student Best Paper Competition
+<!-- ## Student Best Paper Competition
 
  The 2023 American Modelica Conference is pleased to announce the Student Best Paper Award. First-listed authors of regular or invited papers who were students at the time of submission are eligible. The academic advisor must write a nomination letter (maximum of 1 page) describing the contribution of the nominee to the paper and to the state of the art. The nomination letter should also confirm that the first author is a registered student at the time of submission. Note that only a single lead author of a paper can be nominated; if two students on the same paper are nominated, both nominations will be disqualified.
 
 To complete the nomination form, please enter the corresponding information on [EasyChair](https://www.easychair.org/conferences/?conf=namugamc2024) after submitting the paper. The nominations should be entered by August 30, 2024.
-
+ -->

--- a/content/events/modelica2025/call2025.md
+++ b/content/events/modelica2025/call2025.md
@@ -50,8 +50,8 @@ You are encouraged to submit an  **extended abstract**  of 1-2 pages, related to
 
 -   LANG - Modelica Language
 -   LIB - Modelica Libraries
--   FMI - Functional Mockup Interface 
--   eFMI - Functional Mockup Interface for embedded systems
+-   FMI - Functional Mock-up Interface 
+-   eFMI - Functional Mock-up Interface for embedded systems
 -   SSP - System Structure and Parameterization of Components for Virtual System Design
 -   DCP - Distributed Co-Simulation Protocol
 

--- a/content/events/modelica2025/call2025.md
+++ b/content/events/modelica2025/call2025.md
@@ -7,6 +7,7 @@ You are encouraged to submit a full paper of at least 4 pages, with a maximum of
  - Thermodynamic and energy systems applications
  - Mechatronics and robotics applications
  - Medicine and biology applications
+ - Martime and offshore applications
  - Other industrial applications, such as electric drives, power systems, aerospace, etc.
  - Large-scale system modelling
  - Real-time and hardware-in-the-loop simulation


### PR DESCRIPTION
@dzimmer
I have prepared the initial version of the Call for Papers (CFP) for the 16th International Modelica Conference. This draft is based on the structure and content of the “American2024” CFP.

The EasyChair links will be added by me once the corresponding software setup is complete.

If we wish to hold off on officially publishing this CFP until the formal release date of January 6th, I suggest temporarily removing the links to the relevant subpages on the event page. However, from the perspective of the Lucerne University of Applied Sciences and Arts, we are ready to go live.

Best regards and have a great weekend,
Ivo